### PR TITLE
Hide `vec` and `vapp`

### DIFF
--- a/Ex2.agda
+++ b/Ex2.agda
@@ -16,7 +16,7 @@ module Ex2 where
 open import CS410-Prelude
 open import CS410-Monoid
 open import CS410-Nat
-open import CS410-Vec
+open import CS410-Vec hiding (vec; vapp)
 open import CS410-Functor
 
 -- HINT: your tasks are heralded with the eminently searchable tag, "???"


### PR DESCRIPTION
Vector tooling has been moved to `CS410-Vec.agda` but `vec` and `vapp` weren't removed from this file.

They are useful to work out, so hiding them from being imported instead of removing.
